### PR TITLE
Corrected getRecipiesTest() - former version stubbed recipeService.ge…

### DIFF
--- a/src/test/java/guru/springframework/services/RecipeServiceImplTest.java
+++ b/src/test/java/guru/springframework/services/RecipeServiceImplTest.java
@@ -84,7 +84,8 @@ public class RecipeServiceImplTest {
         HashSet receipesData = new HashSet();
         receipesData.add(recipe);
 
-        when(recipeService.getRecipes()).thenReturn(receipesData);
+        //when(recipeService.getRecipes()).thenReturn(receipesData);
+        when(recipeRepository.findAll()).thenReturn(receipesData);
 
         Set<Recipe> recipes = recipeService.getRecipes();
 


### PR DESCRIPTION
Corrected RecipeServiceImplTest.getRecipiesTest() - former version stubbed recipeService.getRecipies(), but it ought to stub the repository.findall() since this is a test for the service.