### PR TITLE
replace deprecated annotation

### DIFF
--- a/src/main/java/guru/springframework/commands/RecipeCommand.java
+++ b/src/main/java/guru/springframework/commands/RecipeCommand.java
@@ -4,11 +4,12 @@ import guru.springframework.domain.Difficulty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.validator.constraints.NotBlank;
+
 import org.hibernate.validator.constraints.URL;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.HashSet;
 import java.util.Set;


### PR DESCRIPTION
looks like org.hibernate.validator.constraints.NotBlank has been deprecated after the course was published