### PR TITLE
Alternative solution with no @JoinTable annotation.

### DIFF
--- a/src/main/java/guru/springframework/domain/Category.java
+++ b/src/main/java/guru/springframework/domain/Category.java
@@ -14,8 +14,8 @@ public class Category {
     private Long id;
     private String description;
 
-    @ManyToMany(mappedBy = "categories")
-    private Set<Recipe> recipes;
+	@ManyToMany(mappedBy="category")
+	private Set<Recipe> recipe;
 
     public Long getId() {
         return id;
@@ -33,11 +33,11 @@ public class Category {
         this.description = description;
     }
 
-    public Set<Recipe> getRecipes() {
-        return recipes;
+    public Set<Recipe> getRecipe() {
+        return recipe;
     }
 
-    public void setRecipes(Set<Recipe> recipes) {
-        this.recipes = recipes;
+    public void setRecipe(Set<Recipe> recipe) {
+        this.recipe = recipe;
     }
 }

--- a/src/main/java/guru/springframework/domain/Recipe.java
+++ b/src/main/java/guru/springframework/domain/Recipe.java
@@ -22,7 +22,7 @@ public class Recipe {
     private String directions;
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "recipe")
-    private Set<Ingredient> ingredients;
+	private Set<Ingredient> ingredient;
 
     @Lob
     private Byte[] image;
@@ -34,10 +34,7 @@ public class Recipe {
     private Notes notes;
 
     @ManyToMany
-    @JoinTable(name = "recipe_category",
-        joinColumns = @JoinColumn(name = "recipe_id"),
-            inverseJoinColumns = @JoinColumn(name = "category_id"))
-    private Set<Category> categories;
+	private Set<Category> category;
 
     public Long getId() {
         return id;
@@ -119,12 +116,12 @@ public class Recipe {
         this.notes = notes;
     }
 
-    public Set<Ingredient> getIngredients() {
-        return ingredients;
+	public Set<Ingredient> getIngredient() {
+		return ingredient;
     }
 
-    public void setIngredients(Set<Ingredient> ingredients) {
-        this.ingredients = ingredients;
+	public void setIngredient(Set<Ingredient> ingredient) {
+		this.ingredient = ingredient;
     }
 
     public Difficulty getDifficulty() {
@@ -135,11 +132,11 @@ public class Recipe {
         this.difficulty = difficulty;
     }
 
-    public Set<Category> getCategories() {
-        return categories;
+	public Set<Category> getCategory() {
+		return category;
     }
 
-    public void setCategories(Set<Category> categories) {
-        this.categories = categories;
+	public void setCategory(Set<Category> category) {
+		this.category = category;
     }
 }


### PR DESCRIPTION
This is an alternative solution to many-to-many-jpa-example with no @JoinTable annotation.

Apparantely, Hibernate or JPA itself doesn't like plural field names, so this leaves me thinking: maybe plural field names are "evil"?.

I found this solution playing with eclipse JPA Diagram Editor, which only (semi-) works "well" with eclipse Luna version.