### PR TITLE
Removes slight confusion due to the use of 1L as recipeId

### DIFF
--- a/src/test/java/guru/springframework/services/IngredientServiceImplTest.java
+++ b/src/test/java/guru/springframework/services/IngredientServiceImplTest.java
@@ -122,7 +122,7 @@ public class IngredientServiceImplTest {
         when(recipeRepository.findById(anyLong())).thenReturn(recipeOptional);
 
         //when
-        ingredientService.deleteById(1L, 3L);
+        ingredientService.deleteById(anyLong(), 3L);     
 
         //then
         verify(recipeRepository, times(1)).findById(anyLong());


### PR DESCRIPTION
use of anyLong() is more appropriate for beginners to understand .