### PR TITLE
Raw types and assertEquals argument order

### DIFF
--- a/src/test/java/guru/springframework/services/RecipeServiceImplTest.java
+++ b/src/test/java/guru/springframework/services/RecipeServiceImplTest.java
@@ -36,14 +36,14 @@ public class RecipeServiceImplTest {
     public void getRecipes() throws Exception {
 
         Recipe recipe = new Recipe();
-        HashSet recipesData = new HashSet();
+        HashSet<Recipe> recipesData = new HashSet<>();
         recipesData.add(recipe);
 
         when(recipeRepository.findAll()).thenReturn(recipesData);
 
         Set<Recipe> recipes = recipeService.getRecipes();
 
-        assertEquals(recipes.size(), 1);
+        assertEquals(1, recipes.size());
         verify(recipeRepository, times(1)).findAll();
     }
 


### PR DESCRIPTION
I've made two improvements:

- Replaced the raw type `HashSet` with parameterized type `HashSet<Recipe>`.
- Changed the order of `assertEquals` arguments so that expected value is first.

