### PR TITLE
Making REST service interface more generic

### DIFF
--- a/src/main/java/guru/springframework/controllers/RecipeController.java
+++ b/src/main/java/guru/springframework/controllers/RecipeController.java
@@ -45,7 +45,7 @@ public class RecipeController {
 
     @PostMapping("recipe")
     public String saveOrUpdate(@ModelAttribute RecipeCommand command){
-        RecipeCommand savedCommand = recipeService.saveRecipeCommand(command);
+        RecipeCommand savedCommand = recipeService.saveRecipe(command);
 
         return "redirect:/recipe/" + savedCommand.getId() + "/show";
     }

--- a/src/main/java/guru/springframework/services/RecipeService.java
+++ b/src/main/java/guru/springframework/services/RecipeService.java
@@ -16,7 +16,7 @@ public interface RecipeService {
 
     RecipeCommand findCommandById(Long l);
 
-    RecipeCommand saveRecipeCommand(RecipeCommand command);
+    RecipeCommand saveRecipe(Object command);
 
     void deleteById(Long idToDelete);
 }

--- a/src/main/java/guru/springframework/services/RecipeServiceImpl.java
+++ b/src/main/java/guru/springframework/services/RecipeServiceImpl.java
@@ -59,8 +59,8 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     @Transactional
-    public RecipeCommand saveRecipeCommand(RecipeCommand command) {
-        Recipe detachedRecipe = recipeCommandToRecipe.convert(command);
+    public RecipeCommand saveRecipe(Object command) {
+        Recipe detachedRecipe = recipeCommandToRecipe.convert((RecipeCommand)command);
 
         Recipe savedRecipe = recipeRepository.save(detachedRecipe);
         log.debug("Saved RecipeId:" + savedRecipe.getId());

--- a/src/test/java/guru/springframework/controllers/RecipeControllerTest.java
+++ b/src/test/java/guru/springframework/controllers/RecipeControllerTest.java
@@ -67,7 +67,7 @@ public class RecipeControllerTest {
         RecipeCommand command = new RecipeCommand();
         command.setId(2L);
 
-        when(recipeService.saveRecipeCommand(any())).thenReturn(command);
+        when(recipeService.saveRecipe(any())).thenReturn(command);
 
         mockMvc.perform(post("/recipe")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)

--- a/src/test/java/guru/springframework/services/RecipeServiceIT.java
+++ b/src/test/java/guru/springframework/services/RecipeServiceIT.java
@@ -46,7 +46,7 @@ public class RecipeServiceIT {
 
         //when
         testRecipeCommand.setDescription(NEW_DESCRIPTION);
-        RecipeCommand savedRecipeCommand = recipeService.saveRecipeCommand(testRecipeCommand);
+        RecipeCommand savedRecipeCommand = recipeService.saveRecipe(testRecipeCommand);
 
         //then
         assertEquals(NEW_DESCRIPTION, savedRecipeCommand.getDescription());


### PR DESCRIPTION
Making interface for RecipeService more generic and not tying up to command objects. This way service interface is easily extensible for handling POST from REST end point