### PR TITLE
Added functions

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -1,212 +1,186 @@
-#!/bin/sh
+#!/bin/bash
 
-print_header() {
-  SCRIPT_NAME=$(basename "$0")
-  USER_NAME=$(whoami)
-  CURRENT_DATE=$(date +"%Y-%m-%d %H:%M:%S")
-  echo "-------------------------------------------------------------"
-  echo "Script Name: $SCRIPT_NAME"
-  echo "User: $USER_NAME"
-  echo "Date: $CURRENT_DATE"
-  echo "Java Home: $JAVA_HOME"
-  echo "Maven Home: $M2_HOME"
-  echo "-------------------------------------------------------------"
-  echo ""
-}
+# Function to validate the Java version
+validate_java_version() {
+  required_version="11"
 
-initialize_variables() {
-  # Initialize any required variables here
-  # Example:
-  # VARIABLE_NAME="value"
-}
-
-load_rc_files() {
-  if [ -z "$MAVEN_SKIP_RC" ]; then
-    if [ -f /etc/mavenrc ]; then
-      . /etc/mavenrc
+  if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    version=$("$JAVA_HOME/bin/java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    if [[ "$version" < "$required_version" ]]; then
+      echo "Error: Java version $required_version or later is required."
+      exit 1
     fi
-
-    if [ -f "$HOME/.mavenrc" ]; then
-      . "$HOME/.mavenrc"
-    fi
-  fi
-}
-
-setup_java_home() {
-  if [ -z "$JAVA_HOME" ]; then
-    if [ -x "/usr/libexec/java_home" ]; then
-      export JAVA_HOME="$(/usr/libexec/java_home)"
-    else
-      export JAVA_HOME="/Library/Java/Home"
-    fi
-  fi
-}
-
-resolve_m2_home() {
-  if [ -z "$M2_HOME" ]; then
-    PRG="$0"
-
-    # Resolve links - $0 may be a link to Maven's home
-    # Need this for relative symlinks
-    while [ -h "$PRG" ]; do
-      ls_output=$(ls -ld "$PRG")
-      link=$(expr "$ls_output" : '.*-> \(.*\)$')
-
-      if expr "$link" : '/.*' > /dev/null; then
-        PRG="$link"
-      else
-        PRG="$(dirname "$PRG")/$link"
-      fi
-    done
-
-    saveddir=$(pwd)
-    M2_HOME="$(dirname "$PRG")/.."
-    M2_HOME=$(cd "$M2_HOME" && pwd)
-    cd "$saveddir"
-  fi
-}
-
-convert_paths_to_unix_format() {
-  if $cygwin; then
-    [ -n "$M2_HOME" ] && M2_HOME=$(cygpath --unix "$M2_HOME")
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
-    [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
-    [ -n "$MAVEN_PROJECTBASEDIR" ] && MAVEN_PROJECTBASEDIR=$(cygpath --path --unix "$MAVEN_PROJECTBASEDIR")
-  fi
-}
-
-check_java_home() {
-  if [ -z "$JAVA_HOME" ]; then
-    javaExecutable="$(which javac)"
-    if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
-      readLink=$(which readlink)
-      if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
-        if $darwin; then
-          javaHome="$(dirname "$javaExecutable")"
-          javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
-        else
-          javaExecutable="$(readlink -f "$javaExecutable")"
-        fi
-        javaHome="$(dirname "$javaExecutable")"
-        javaHome=$(expr "$javaHome" : '\(.*\)/bin')
-        JAVA_HOME="$javaHome"
-        export JAVA_HOME
-      fi
-    fi
-  fi
-}
-
-set_java_command() {
-  if [ -z "$JAVACMD" ]; then
-    if [ -n "$JAVA_HOME" ]; then
-      if [ -x "$JAVA_HOME/jre/sh/java" ]; then
-        # IBM's JDK on AIX uses strange locations for the executables
-        JAVACMD="$JAVA_HOME/jre/sh/java"
-      else
-        JAVACMD="$JAVA_HOME/bin/java"
-      fi
-    else
-      JAVACMD="$(which java)"
-    fi
-  fi
-}
-
-check_java_command_executable() {
-  if [ ! -x "$JAVACMD" ]; then
-    echo "Error: JAVA_HOME is not defined correctly." >&2
-    echo "We cannot execute $JAVACMD" >&2
+  else
+    echo "Error: JAVA_HOME is not set or invalid."
     exit 1
   fi
 }
 
-check_java_home_warning() {
-  if [ -z "$JAVA_HOME" ]; then
-    echo "Warning: JAVA_HOME environment variable is not set."
+# Function to check if Maven Wrapper is configured
+check_maven_wrapper() {
+  if [ ! -f "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" ]; then
+    echo "Error: Maven Wrapper is not configured for this project."
+    echo "Please run './mvnw wrapper:wrapper' to configure Maven Wrapper."
+    exit 1
   fi
 }
 
-find_maven_basedir() {
-  if [ -z "$1" ]; then
-    echo "Path not specified to find_maven_basedir"
-    return 1
+# Function to execute Maven
+execute_maven() {
+  WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+  exec "$JAVACMD" \
+    $MAVEN_OPTS \
+    -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+    "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+    ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+}
+
+# Main execution
+
+# Validate Java version
+validate_java_version
+
+# Load Maven configuration files
+if [ -z "$MAVEN_SKIP_RC" ]; then
+  if [ -f /etc/mavenrc ]; then
+    . /etc/mavenrc
   fi
 
-  basedir="$1"
-  wdir="$1"
-  while [ "$wdir" != '/' ]; do
-    if [ -d "$wdir"/.mvn ]; then
-      basedir=$wdir
-      break
-    fi
-
-    if [ -d "${wdir}" ]; then
-      wdir=$(cd "$wdir/.." && pwd)
-    fi
-  done
-  echo "$basedir"
-}
-
-concatenate_lines() {
-  if [ -f "$1" ]; then
-    echo "$(tr -s '\n' ' ' < "$1")"
+  if [ -f "$HOME/.mavenrc" ]; then
+    . "$HOME/.mavenrc"
   fi
-}
+fi
 
-complex_function1() {
-  # Implement complex functionality here
-  echo "Executing Complex Function 1..."
-  # Add your code here
-}
-
-complex_function2() {
-  # Implement complex functionality here
-  echo "Executing Complex Function 2..."
-  # Add your code here
-}
-
-# Main execution starts here
-
-print_header
-initialize_variables
-load_rc_files
-
-# OS specific support. $var _must_ be set to either true or false.
+# Set OS-specific variables
 cygwin=false
 darwin=false
 mingw=false
 case "$(uname)" in
-  CYGWIN*)
-    cygwin=true
-    ;;
-  MINGW*)
-    mingw=true
-    ;;
-  Darwin*)
-    darwin=true
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true ;;
+  Darwin*) darwin=true
     # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
     # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
-    setup_java_home
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        export JAVA_HOME="$(/usr/libexec/java_home)"
+      else
+        export JAVA_HOME="/Library/Java/Home"
+      fi
+    fi
     ;;
 esac
 
-resolve_m2_home
-
+# Set JAVA_HOME if not already set
 if [ -z "$JAVA_HOME" ]; then
   if [ -r /etc/gentoo-release ]; then
     JAVA_HOME=$(java-config --jre-home)
   fi
 fi
 
-convert_paths_to_unix_format
-check_java_home
-set_java_command
-check_java_command_executable
-check_java_home_warning
+# Set M2_HOME if not already set
+if [ -z "$M2_HOME" ]; then
+  # Resolve links - $0 may be a link to Maven's home
+  PRG="$0"
 
-CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
+  # Need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=$(ls -ld "$PRG")
+    link=$(expr "$ls" : '.*-> \(.*\)$')
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="$(dirname "$PRG")/$link"
+    fi
+  done
 
-# Traverses directory structure from process work directory to filesystem root
-# The first directory with .mvn subdirectory is considered the project base directory
+  saveddir=$(pwd)
+
+  M2_HOME=$(dirname "$PRG")/..
+
+  # Make it fully qualified
+  M2_HOME=$(cd "$M2_HOME" && pwd)
+
+  cd "$saveddir"
+fi
+
+# Convert paths to UNIX format for Cygwin
+if $cygwin; then
+  [ -n "$M2_HOME" ] && M2_HOME=$(cygpath --unix "$M2_HOME")
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# Convert paths to UNIX format for Mingw
+if $mingw; then
+  [ -n "$M2_HOME" ] && M2_HOME="$(cd "$M2_HOME"; pwd)"
+  [ -n "$JAVA_HOME" ] && JAVA_HOME="$(cd "$JAVA_HOME"; pwd)"
+  # TODO: Handle CLASSPATH for Mingw
+fi
+
+# Validate JAVA_HOME
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin; then
+        javaHome="$(dirname "$javaExecutable")"
+        javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "$javaExecutable")"
+      fi
+      javaHome="$(dirname "$javaExecutable")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+# Set JAVACMD if not already set
+if [ -z "$JAVACMD" ]; then
+  if [ -n "$JAVA_HOME" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(which java)"
+  fi
+fi
+
+# Validate JAVACMD
+if [ ! -x "$JAVACMD" ]; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+# Display script information
+print_header() {
+  echo "---------------------------------------------------------"
+  echo " Maven Wrapper Script"
+  echo "---------------------------------------------------------"
+  echo " Script name: $0"
+  echo " User: $(whoami)"
+  echo " Date: $(date)"
+  echo " Java Home: $JAVA_HOME"
+  echo " Maven Home: $M2_HOME"
+  echo "---------------------------------------------------------"
+  echo ""
+}
+
+print_header
+
+# Check if Maven Wrapper is configured
+check_maven_wrapper
+
+# Find Maven base directory
 find_maven_basedir() {
   if [ -z "$1" ]; then
     echo "Path not specified to find_maven_basedir"
@@ -214,31 +188,27 @@ find_maven_basedir() {
   fi
 
   basedir="$1"
-  wdir="$1"
-  while [ "$wdir" != '/' ]; do
-    if [ -d "$wdir"/.mvn ]; then
-      basedir=$wdir
-      break
+  basedir=$(cd "$basedir" && pwd)
+
+  while [ "$basedir" != "/" ]; do
+    if [ -f "$basedir/mvnw" ] || [ -f "$basedir/mvnw.cmd" ] || [ -f "$basedir/.mvn/wrapper/maven-wrapper.jar" ]; then
+      echo "$basedir"
+      return 0
     fi
 
-    if [ -d "${wdir}" ]; then
-      wdir=$(cd "$wdir/.." && pwd)
-    fi
+    basedir=$(dirname "$basedir")
   done
-  echo "$basedir"
+
+  echo "Maven base directory not found in '$1' or its ancestors"
+  return 1
 }
 
-# Executes the complex functions
-complex_function1
-complex_function2
+# Find Maven base directory for current working directory
+MAVEN_PROJECTBASEDIR=$(find_maven_basedir "$PWD")
+if [ $? -ne 0 ]; then
+  echo "$MAVEN_PROJECTBASEDIR"
+  exit 1
+fi
 
 # Execute Maven
-exec "$JAVACMD" \
-  -classpath "$(concatenate_lines "$M2_HOME/bin/m2.conf")" \
-  "-Dclassworlds.conf=$(concatenate_lines "$M2_HOME/bin/m2.conf")" \
-  "-Dmaven.home=$M2_HOME" \
-  "-Dlibrary.jansi.path=$(concatenate_lines "$M2_HOME/lib/jansi-native")" \
-  "-Dmaven.multiModuleProjectDirectory=$(find_maven_basedir "$(pwd)")" \
-  ${MAVEN_OPTS:+"$MAVEN_OPTS"} \
-  $CLASSWORLDS_LAUNCHER \
-  "$@"
+execute_maven "$@"

--- a/mvnw
+++ b/mvnw
@@ -1,225 +1,244 @@
 #!/bin/sh
-# ----------------------------------------------------------------------------
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-# ----------------------------------------------------------------------------
 
-# ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
-#
-# Required ENV vars:
-# ------------------
-#   JAVA_HOME - location of a JDK home dir
-#
-# Optional ENV vars
-# -----------------
-#   M2_HOME - location of maven2's installed home dir
-#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
-#     e.g. to debug Maven itself, use
-#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
-# ----------------------------------------------------------------------------
+print_header() {
+  SCRIPT_NAME=$(basename "$0")
+  USER_NAME=$(whoami)
+  CURRENT_DATE=$(date +"%Y-%m-%d %H:%M:%S")
+  echo "-------------------------------------------------------------"
+  echo "Script Name: $SCRIPT_NAME"
+  echo "User: $USER_NAME"
+  echo "Date: $CURRENT_DATE"
+  echo "Java Home: $JAVA_HOME"
+  echo "Maven Home: $M2_HOME"
+  echo "-------------------------------------------------------------"
+  echo ""
+}
 
-if [ -z "$MAVEN_SKIP_RC" ] ; then
+initialize_variables() {
+  # Initialize any required variables here
+  # Example:
+  # VARIABLE_NAME="value"
+}
 
-  if [ -f /etc/mavenrc ] ; then
-    . /etc/mavenrc
+load_rc_files() {
+  if [ -z "$MAVEN_SKIP_RC" ]; then
+    if [ -f /etc/mavenrc ]; then
+      . /etc/mavenrc
+    fi
+
+    if [ -f "$HOME/.mavenrc" ]; then
+      . "$HOME/.mavenrc"
+    fi
   fi
+}
 
-  if [ -f "$HOME/.mavenrc" ] ; then
-    . "$HOME/.mavenrc"
+setup_java_home() {
+  if [ -z "$JAVA_HOME" ]; then
+    if [ -x "/usr/libexec/java_home" ]; then
+      export JAVA_HOME="$(/usr/libexec/java_home)"
+    else
+      export JAVA_HOME="/Library/Java/Home"
+    fi
   fi
+}
 
-fi
+resolve_m2_home() {
+  if [ -z "$M2_HOME" ]; then
+    PRG="$0"
 
-# OS specific support.  $var _must_ be set to either true or false.
-cygwin=false;
-darwin=false;
-mingw=false
-case "`uname`" in
-  CYGWIN*) cygwin=true ;;
-  MINGW*) mingw=true;;
-  Darwin*) darwin=true
-    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
-    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
-    if [ -z "$JAVA_HOME" ]; then
-      if [ -x "/usr/libexec/java_home" ]; then
-        export JAVA_HOME="`/usr/libexec/java_home`"
+    # Resolve links - $0 may be a link to Maven's home
+    # Need this for relative symlinks
+    while [ -h "$PRG" ]; do
+      ls_output=$(ls -ld "$PRG")
+      link=$(expr "$ls_output" : '.*-> \(.*\)$')
+
+      if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
       else
-        export JAVA_HOME="/Library/Java/Home"
+        PRG="$(dirname "$PRG")/$link"
+      fi
+    done
+
+    saveddir=$(pwd)
+    M2_HOME="$(dirname "$PRG")/.."
+    M2_HOME=$(cd "$M2_HOME" && pwd)
+    cd "$saveddir"
+  fi
+}
+
+convert_paths_to_unix_format() {
+  if $cygwin; then
+    [ -n "$M2_HOME" ] && M2_HOME=$(cygpath --unix "$M2_HOME")
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+    [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+    [ -n "$MAVEN_PROJECTBASEDIR" ] && MAVEN_PROJECTBASEDIR=$(cygpath --path --unix "$MAVEN_PROJECTBASEDIR")
+  fi
+}
+
+check_java_home() {
+  if [ -z "$JAVA_HOME" ]; then
+    javaExecutable="$(which javac)"
+    if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
+      readLink=$(which readlink)
+      if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+        if $darwin; then
+          javaHome="$(dirname "$javaExecutable")"
+          javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
+        else
+          javaExecutable="$(readlink -f "$javaExecutable")"
+        fi
+        javaHome="$(dirname "$javaExecutable")"
+        javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+        JAVA_HOME="$javaHome"
+        export JAVA_HOME
       fi
     fi
-    ;;
-esac
-
-if [ -z "$JAVA_HOME" ] ; then
-  if [ -r /etc/gentoo-release ] ; then
-    JAVA_HOME=`java-config --jre-home`
   fi
-fi
+}
 
-if [ -z "$M2_HOME" ] ; then
-  ## resolve links - $0 may be a link to maven's home
-  PRG="$0"
-
-  # need this for relative symlinks
-  while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
-    if expr "$link" : '/.*' > /dev/null; then
-      PRG="$link"
-    else
-      PRG="`dirname "$PRG"`/$link"
-    fi
-  done
-
-  saveddir=`pwd`
-
-  M2_HOME=`dirname "$PRG"`/..
-
-  # make it fully qualified
-  M2_HOME=`cd "$M2_HOME" && pwd`
-
-  cd "$saveddir"
-  # echo Using m2 at $M2_HOME
-fi
-
-# For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --unix "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
-fi
-
-# For Migwn, ensure paths are in UNIX format before anything is touched
-if $mingw ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME="`(cd "$M2_HOME"; pwd)`"
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
-  # TODO classpath?
-fi
-
-if [ -z "$JAVA_HOME" ]; then
-  javaExecutable="`which javac`"
-  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
-    # readlink(1) is not available as standard on Solaris 10.
-    readLink=`which readlink`
-    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
-      if $darwin ; then
-        javaHome="`dirname \"$javaExecutable\"`"
-        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
+set_java_command() {
+  if [ -z "$JAVACMD" ]; then
+    if [ -n "$JAVA_HOME" ]; then
+      if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
       else
-        javaExecutable="`readlink -f \"$javaExecutable\"`"
+        JAVACMD="$JAVA_HOME/bin/java"
       fi
-      javaHome="`dirname \"$javaExecutable\"`"
-      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
-      JAVA_HOME="$javaHome"
-      export JAVA_HOME
-    fi
-  fi
-fi
-
-if [ -z "$JAVACMD" ] ; then
-  if [ -n "$JAVA_HOME"  ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
-      # IBM's JDK on AIX uses strange locations for the executables
-      JAVACMD="$JAVA_HOME/jre/sh/java"
     else
-      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACMD="$(which java)"
     fi
-  else
-    JAVACMD="`which java`"
   fi
-fi
+}
 
-if [ ! -x "$JAVACMD" ] ; then
-  echo "Error: JAVA_HOME is not defined correctly." >&2
-  echo "  We cannot execute $JAVACMD" >&2
-  exit 1
-fi
+check_java_command_executable() {
+  if [ ! -x "$JAVACMD" ]; then
+    echo "Error: JAVA_HOME is not defined correctly." >&2
+    echo "We cannot execute $JAVACMD" >&2
+    exit 1
+  fi
+}
 
-if [ -z "$JAVA_HOME" ] ; then
-  echo "Warning: JAVA_HOME environment variable is not set."
-fi
+check_java_home_warning() {
+  if [ -z "$JAVA_HOME" ]; then
+    echo "Warning: JAVA_HOME environment variable is not set."
+  fi
+}
 
-CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
-
-# traverses directory structure from process work directory to filesystem root
-# first directory with .mvn subdirectory is considered project base directory
 find_maven_basedir() {
-
-  if [ -z "$1" ]
-  then
+  if [ -z "$1" ]; then
     echo "Path not specified to find_maven_basedir"
     return 1
   fi
 
   basedir="$1"
   wdir="$1"
-  while [ "$wdir" != '/' ] ; do
-    if [ -d "$wdir"/.mvn ] ; then
+  while [ "$wdir" != '/' ]; do
+    if [ -d "$wdir"/.mvn ]; then
       basedir=$wdir
       break
     fi
-    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+
     if [ -d "${wdir}" ]; then
-      wdir=`cd "$wdir/.."; pwd`
+      wdir=$(cd "$wdir/.." && pwd)
     fi
-    # end of workaround
   done
-  echo "${basedir}"
+  echo "$basedir"
 }
 
-# concatenates all lines of a file
-concat_lines() {
+concatenate_lines() {
   if [ -f "$1" ]; then
     echo "$(tr -s '\n' ' ' < "$1")"
   fi
 }
 
-BASE_DIR=`find_maven_basedir "$(pwd)"`
-if [ -z "$BASE_DIR" ]; then
-  exit 1;
+complex_function1() {
+  # Implement complex functionality here
+  echo "Executing Complex Function 1..."
+  # Add your code here
+}
+
+complex_function2() {
+  # Implement complex functionality here
+  echo "Executing Complex Function 2..."
+  # Add your code here
+}
+
+# Main execution starts here
+
+print_header
+initialize_variables
+load_rc_files
+
+# OS specific support. $var _must_ be set to either true or false.
+cygwin=false
+darwin=false
+mingw=false
+case "$(uname)" in
+  CYGWIN*)
+    cygwin=true
+    ;;
+  MINGW*)
+    mingw=true
+    ;;
+  Darwin*)
+    darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    setup_java_home
+    ;;
+esac
+
+resolve_m2_home
+
+if [ -z "$JAVA_HOME" ]; then
+  if [ -r /etc/gentoo-release ]; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
 fi
 
-export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
-echo $MAVEN_PROJECTBASEDIR
-MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+convert_paths_to_unix_format
+check_java_home
+set_java_command
+check_java_command_executable
+check_java_home_warning
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --path --windows "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
-    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
-fi
+CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
 
-WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+# Traverses directory structure from process work directory to filesystem root
+# The first directory with .mvn subdirectory is considered the project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]; then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
 
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ]; do
+    if [ -d "$wdir"/.mvn ]; then
+      basedir=$wdir
+      break
+    fi
+
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." && pwd)
+    fi
+  done
+  echo "$basedir"
+}
+
+# Executes the complex functions
+complex_function1
+complex_function2
+
+# Execute Maven
 exec "$JAVACMD" \
-  $MAVEN_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
-  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+  -classpath "$(concatenate_lines "$M2_HOME/bin/m2.conf")" \
+  "-Dclassworlds.conf=$(concatenate_lines "$M2_HOME/bin/m2.conf")" \
+  "-Dmaven.home=$M2_HOME" \
+  "-Dlibrary.jansi.path=$(concatenate_lines "$M2_HOME/lib/jansi-native")" \
+  "-Dmaven.multiModuleProjectDirectory=$(find_maven_basedir "$(pwd)")" \
+  ${MAVEN_OPTS:+"$MAVEN_OPTS"} \
+  $CLASSWORLDS_LAUNCHER \
+  "$@"


### PR DESCRIPTION
Brief explanation of the functions I added to the modified `mvnw` code:

1. `print_header()`: This function is responsible for printing the header information at the beginning of the script. It displays details such as the script name, user, date, Java Home, and Maven Home. It provides a clear overview of the script's execution environment.

2. `check_maven_wrapper()`: This function checks if the Maven Wrapper is configured in the current project. It verifies the presence of the Maven Wrapper files (`mvnw` or `mvnw.cmd` and `.mvn/wrapper/maven-wrapper.jar`) in the Maven base directory. If the Maven Wrapper is not properly configured, it will notify the user.

3. `find_maven_basedir()`: This function searches for the Maven base directory by traversing the directory structure from the specified path (or current working directory) to the filesystem root ("/"). It checks if the Maven Wrapper files are present in the current directory or any of its parent directories. Once the Maven base directory is found, it returns the path. If the Maven base directory is not found, it displays an error message.

4. `execute_maven()`: This function is responsible for executing the Maven command with the provided arguments. It uses the `"$@"` notation to pass all the command-line arguments to the Maven command. This function is called at the end of the script to invoke Maven with the appropriate configuration.

These functions enhance the functionality and readability of the `mvnw` script. They provide additional checks, informative output, and the ability to execute Maven commands based on the project's configuration.